### PR TITLE
fix SEGV

### DIFF
--- a/request/oauth2.go
+++ b/request/oauth2.go
@@ -111,7 +111,7 @@ func tokenRequest(v url.Values,request *AurlExecution) (*string, error) {
 	if dumpReq, err := httputil.DumpRequestOut(req, true); err == nil {
 		log.Printf("Token request >>>\n%s\n<<<", string(dumpReq))
 	} else {
-		log.Printf("Token request dump failed: ", err)
+		log.Printf("Token request dump failed: %s", err)
 	}
 
 	client := &http.Client{
@@ -122,16 +122,17 @@ func tokenRequest(v url.Values,request *AurlExecution) (*string, error) {
 		},
 	}
 	resp, err := client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		log.Printf("Token request failed: %s", err.Error())
 		return nil, err
 	}
 
+	defer resp.Body.Close()
+
 	if dumpResp, err := httputil.DumpResponse(resp, true); err == nil {
 		log.Printf("Token response >>>\n%s\n<<<", string(dumpResp))
 	} else {
-		log.Printf("Token response dump failed: ", err)
+		log.Printf("Token response dump failed: %s", err)
 	}
 
 	if resp.StatusCode == 200 {


### PR DESCRIPTION
エラーが見えなくて泣いてる

悲しい

## 再現条件

存在しないソケット通信先を指定すると発生します。