### PR TITLE
オプションで指定したUserAgentヘッダーをトークン取得時に使用する

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Section name is utilized as profile name.  In each section following key setting
 | username                      | username for password grant       | (none)        | (any)            | no (except for password grant)  |
 | password                      | password for password grant       | (none)        | (any)            | no (except for password grant)  |
 | default\_content\_type        | default content type header       | (none)        | (any)            | no                              |
+| default\_user\_agent          | default user agent   header       | aurl x.x.x    | (any)            | no                              |
 
 
 Implicit flow is not supported currently.

--- a/cli.go
+++ b/cli.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/classmethod/aurl/profiles"
 	"github.com/classmethod/aurl/request"
+	version "github.com/classmethod/aurl/version"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -38,7 +39,7 @@ var (
 
 // Run invokes the CLI with the given arguments.
 func (cli *CLI) Run(args []string) int {
-	kingpin.UsageTemplate(kingpin.CompactUsageTemplate).Version(Version).Author(Author)
+	kingpin.UsageTemplate(kingpin.CompactUsageTemplate).Version(version.Version).Author(version.Author)
 	kingpin.CommandLine.VersionFlag.Short('V')
 	kingpin.CommandLine.HelpFlag.Short('h')
 	kingpin.CommandLine.Help = "Command line utility to make HTTP request with OAuth2."
@@ -68,8 +69,8 @@ func (cli *CLI) Run(args []string) int {
 		return ExitCodeError
 	} else {
 		execution := &request.AurlExecution{
-			Name:    Name,
-			Version: Version,
+			Name:    version.Name,
+			Version: version.Version,
 
 			Profile:      profile,
 			Method:       method,

--- a/profiles/profile.go
+++ b/profiles/profile.go
@@ -20,6 +20,7 @@ type Profile struct {
 	Username              string
 	Password              string
 	DefaultContentType    string
+	UserAgent             string
 }
 
 const (
@@ -35,6 +36,7 @@ const (
 	USERNAME                   = "username"
 	PASSWORD                   = "password"
 	DEFAULT_CONTENT_TYPE       = "default_content_type"
+	DEFAULT_USER_AGENT         = "default_user_agent"
 	//SOURCE_PROFILE             = "source_profile"
 
 	DEFAULT_CLIENT_ID     = "aurl"
@@ -59,6 +61,7 @@ func LoadProfile(profileName string) (Profile, error) {
 			Username:              getOrDefault(p, USERNAME, ""),
 			Password:              getOrDefault(p, PASSWORD, ""),
 			DefaultContentType:    getOrDefault(p, DEFAULT_CONTENT_TYPE, ""),
+			UserAgent:             getOrDefault(p, DEFAULT_USER_AGENT, ""),
 		}, nil
 	} else {
 		return Profile{}, errors.New("Unknown profile: " + profileName)

--- a/profiles/profile.go
+++ b/profiles/profile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/classmethod/aurl/utils"
+	version "github.com/classmethod/aurl/version"
 	ini "github.com/rakyll/goini"
 )
 
@@ -61,7 +62,7 @@ func LoadProfile(profileName string) (Profile, error) {
 			Username:              getOrDefault(p, USERNAME, ""),
 			Password:              getOrDefault(p, PASSWORD, ""),
 			DefaultContentType:    getOrDefault(p, DEFAULT_CONTENT_TYPE, ""),
-			UserAgent:             getOrDefault(p, DEFAULT_USER_AGENT, ""),
+			UserAgent:             getOrDefault(p, DEFAULT_USER_AGENT, fmt.Sprintf("%s-%s", version.Name, version.Version)),
 		}, nil
 	} else {
 		return Profile{}, errors.New("Unknown profile: " + profileName)

--- a/request/oauth2.go
+++ b/request/oauth2.go
@@ -109,13 +109,10 @@ func tokenRequest(v url.Values, request *AurlExecution) (*string, error) {
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Accept", "application/json")
 
-	if request.Headers.Get("User-Agent") != "" {
-		req.Header.Add("User-Agent", request.Headers.Get("User-Agent"))
-	} else if (request.Profile.UserAgent != ""){
+	if request.Headers.Get("User-Agent") == "" {
 		req.Header.Add("User-Agent", request.Profile.UserAgent)
-	} else {
-		req.Header.Add("User-Agent", fmt.Sprintf("%s-%s", request.Name, request.Version))
 	}
+
 	req.SetBasicAuth(request.Profile.ClientId, request.Profile.ClientSecret)
 
 	if dumpReq, err := httputil.DumpRequestOut(req, true); err == nil {

--- a/request/oauth2.go
+++ b/request/oauth2.go
@@ -108,6 +108,11 @@ func tokenRequest(v url.Values, request *AurlExecution) (*string, error) {
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Accept", "application/json")
+	if request.Headers.Get("User-Agent") == "" {
+		req.Header.Add("User-Agent", fmt.Sprintf("%s-%s", request.Name, request.Version))
+	} else {
+		req.Header.Add("User-Agent", request.Headers.Get("User-Agent"))
+	}
 	req.SetBasicAuth(request.Profile.ClientId, request.Profile.ClientSecret)
 
 	if dumpReq, err := httputil.DumpRequestOut(req, true); err == nil {

--- a/request/oauth2.go
+++ b/request/oauth2.go
@@ -108,10 +108,13 @@ func tokenRequest(v url.Values, request *AurlExecution) (*string, error) {
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Accept", "application/json")
-	if request.Headers.Get("User-Agent") == "" {
-		req.Header.Add("User-Agent", fmt.Sprintf("%s-%s", request.Name, request.Version))
-	} else {
+
+	if request.Headers.Get("User-Agent") != "" {
 		req.Header.Add("User-Agent", request.Headers.Get("User-Agent"))
+	} else if (request.Profile.UserAgent != ""){
+		req.Header.Add("User-Agent", request.Profile.UserAgent)
+	} else {
+		req.Header.Add("User-Agent", fmt.Sprintf("%s-%s", request.Name, request.Version))
 	}
 	req.SetBasicAuth(request.Profile.ClientId, request.Profile.ClientSecret)
 

--- a/request/request.go
+++ b/request/request.go
@@ -134,12 +134,9 @@ func (execution *AurlExecution) doRequest(tokenResponse tokens.TokenResponse, pr
 	}
 
 	req.Header = *execution.Headers
+
 	if req.Header.Get("User-Agent") == "" {
-		if execution.Profile.UserAgent != "" {
-			req.Header.Set("User-Agent", execution.Profile.UserAgent)
-		} else {
-			req.Header.Set("User-Agent", fmt.Sprintf("%s-%s", execution.Name, execution.Version))
-		}
+		req.Header.Set("User-Agent", profile.UserAgent)
 	}
 
 	if req.Header.Get("Content-Type") == "" {

--- a/request/request.go
+++ b/request/request.go
@@ -135,8 +135,13 @@ func (execution *AurlExecution) doRequest(tokenResponse tokens.TokenResponse, pr
 
 	req.Header = *execution.Headers
 	if req.Header.Get("User-Agent") == "" {
-		req.Header.Set("User-Agent", fmt.Sprintf("%s-%s", execution.Name, execution.Version))
+		if execution.Profile.UserAgent != "" {
+			req.Header.Set("User-Agent", execution.Profile.UserAgent)
+		} else {
+			req.Header.Set("User-Agent", fmt.Sprintf("%s-%s", execution.Name, execution.Version))
+		}
 	}
+
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", profile.DefaultContentType)
 	}
@@ -154,7 +159,11 @@ func (execution *AurlExecution) doRequest(tokenResponse tokens.TokenResponse, pr
 			log.Printf("Original request Host = %s", req.URL.String())
 			redirectRequest.Header = *execution.Headers
 			if redirectRequest.Header.Get("User-Agent") == "" {
-				redirectRequest.Header.Set("User-Agent", fmt.Sprintf("%s-%s", execution.Name, execution.Version))
+				if execution.Profile.UserAgent != "" {
+					req.Header.Set("User-Agent", execution.Profile.UserAgent)
+				} else {
+					req.Header.Set("User-Agent", fmt.Sprintf("%s-%s", execution.Name, execution.Version))
+				}
 			}
 			if matchServer(redirectRequest.URL, req.URL) {
 				log.Printf("Propagate authorization header")

--- a/request/request.go
+++ b/request/request.go
@@ -156,11 +156,7 @@ func (execution *AurlExecution) doRequest(tokenResponse tokens.TokenResponse, pr
 			log.Printf("Original request Host = %s", req.URL.String())
 			redirectRequest.Header = *execution.Headers
 			if redirectRequest.Header.Get("User-Agent") == "" {
-				if execution.Profile.UserAgent != "" {
-					req.Header.Set("User-Agent", execution.Profile.UserAgent)
-				} else {
-					req.Header.Set("User-Agent", fmt.Sprintf("%s-%s", execution.Name, execution.Version))
-				}
+				redirectRequest.Header.Set("User-Agent", profile.UserAgent)
 			}
 			if matchServer(redirectRequest.URL, req.URL) {
 				log.Printf("Propagate authorization header")

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-package main
+package version
 
 const Name string = "aurl"
 const Version string = "1.1.0-SNAPSHOT"


### PR DESCRIPTION
以下の点を変更

- `-H` オプションで指定したUserAgentをトークン取得時にも使用する
- プロファイルにデフォルトUserAgentを指定できるようにした
- 上記に伴ってUA未指定時のトークン取得リクエストUAを`aurl`に変更
