### PR TITLE
Add prompting for client secret and password

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -24,16 +24,17 @@ type CLI struct {
 }
 
 var (
-	profileName  = kingpin.Flag("profile", "Set profile name. (default: \"default\")").Short('p').Default("default").String()
-	method       = kingpin.Flag("request", "Set HTTP request method. (default: \"GET\")").Short('X').Default("GET").String()
-	headers      = HTTPHeader(kingpin.Flag("header", "Add HTTP headers to the request.").Short('H').PlaceHolder("HEADER:VALUE"))
-	data         = kingpin.Flag("data", "Set HTTP request body.").Short('d').String()
-	insecure     = kingpin.Flag("insecure", "Disable SSL certificate verification.").Short('k').Bool()
-	printBody    = kingpin.Flag("print-body", "Enable printing response body to stdout. (default: enabled, try --no-print-body)").Default("true").Bool()
-	printHeaders = kingpin.Flag("print-headers", "Enable printing response headers JSON to stdout. (default: disabled, try --no-print-headers)").Bool()
-	verbose      = kingpin.Flag("verbose", "Enable verbose logging to stderr.").Short('v').Bool()
-
-	targetUrl = kingpin.Arg("url", "The URL to request").Required().String()
+	profileName        = kingpin.Flag("profile", "Set profile name. (default: \"default\")").Short('p').Default("default").String()
+	method             = kingpin.Flag("request", "Set HTTP request method. (default: \"GET\")").Short('X').Default("GET").String()
+	headers            = HTTPHeader(kingpin.Flag("header", "Add HTTP headers to the request.").Short('H').PlaceHolder("HEADER:VALUE"))
+	data               = kingpin.Flag("data", "Set HTTP request body.").Short('d').String()
+	insecure           = kingpin.Flag("insecure", "Disable SSL certificate verification.").Short('k').Bool()
+	printBody          = kingpin.Flag("print-body", "Enable printing response body to stdout. (default: enabled, try --no-print-body)").Default("true").Bool()
+	printHeaders       = kingpin.Flag("print-headers", "Enable printing response headers JSON to stdout. (default: disabled, try --no-print-headers)").Bool()
+	promptClientSecret = kingpin.Flag("prompt-client-secret", "Enable prompting for client secret. (default: disabled)").Bool()
+	promptPassword     = kingpin.Flag("prompt-password", "Enable prompting for password. (default: disabled)").Bool()
+	verbose            = kingpin.Flag("verbose", "Enable verbose logging to stderr.").Short('v').Bool()
+	targetUrl          = kingpin.Arg("url", "The URL to request").Required().String()
 )
 
 // Run invokes the CLI with the given arguments.
@@ -60,6 +61,8 @@ func (cli *CLI) Run(args []string) int {
 	log.Printf("  insecure: %v\n", *insecure)
 	log.Printf("  printBody: %v\n", *printBody)
 	log.Printf("  printHeaders: %v\n", *printHeaders)
+	log.Printf("  promptClientSecret: %v\n", *promptClientSecret)
+	log.Printf("  promptPassword: %v\n", *promptPassword)
 	log.Printf("  verbose: %v\n", *verbose)
 	log.Printf("  targetUrl: %v\n", *targetUrl)
 
@@ -74,13 +77,15 @@ func (cli *CLI) Run(args []string) int {
 			Name:    name,
 			Version: version,
 
-			Profile:      profile,
-			Method:       method,
-			Headers:      headers,
-			Data:         data,
-			Insecure:     insecure,
-			PrintBody:    printBody,
-			PrintHeaders: printHeaders,
+			Profile:            profile,
+			Method:             method,
+			Headers:            headers,
+			Data:               data,
+			Insecure:           insecure,
+			PrintBody:          printBody,
+			PrintHeaders:       printHeaders,
+			PromptClientSecret: promptClientSecret,
+			PromptPassword:     promptPassword,
 
 			TargetUrl: targetUrl,
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/classmethod/aurl
 go 1.19
 
 require (
+	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rakyll/goini v0.0.0-20140112234134-907cca0f578a
 	github.com/toqueteos/webbrowser v1.2.0
@@ -14,4 +15,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/crypto v0.10.0 // indirect
+	golang.org/x/sys v0.9.0 // indirect
+	golang.org/x/term v0.9.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
+github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -17,6 +19,12 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
+golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
+golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
+golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
+golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.9.0 h1:GRRCnKYhdQrD8kfRAdQ6Zcw1P0OcELxGLKJvtjVMZ28=
+golang.org/x/term v0.9.0/go.mod h1:M6DEAAIenWoTxdKrOltXcmDY3rSplQUkrvaDU5FcQyo=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/request/request.go
+++ b/request/request.go
@@ -15,19 +15,22 @@ import (
 
 	"github.com/classmethod/aurl/profiles"
 	"github.com/classmethod/aurl/tokens"
+	"github.com/howeyc/gopass"
 )
 
 type AurlExecution struct {
 	Name    string
 	Version string
 
-	Profile      profiles.Profile
-	Method       *string
-	Headers      *http.Header
-	Data         *string
-	Insecure     *bool
-	PrintBody    *bool
-	PrintHeaders *bool
+	Profile            profiles.Profile
+	Method             *string
+	Headers            *http.Header
+	Data               *string
+	Insecure           *bool
+	PrintBody          *bool
+	PrintHeaders       *bool
+	PromptClientSecret *bool
+	PromptPassword     *bool
 
 	TargetUrl *string
 }
@@ -112,6 +115,22 @@ func (execution *AurlExecution) refresh(tokenResponse tokens.TokenResponse) (*st
 }
 
 func (execution *AurlExecution) grant() (*string, error) {
+	if *execution.PromptClientSecret {
+		clientSecret, err := gopass.GetPasswdPrompt("Enter client secret: ", true, os.Stdin, os.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		execution.Profile.ClientSecret = string(clientSecret)
+	}
+
+	if *execution.PromptPassword {
+		password, err := gopass.GetPasswdPrompt("Enter password: ", true, os.Stdin, os.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		execution.Profile.Password = string(password)
+	}
+
 	switch execution.Profile.GrantType {
 	case "authorization_code":
 		return authCodeGrant(execution)


### PR DESCRIPTION
This PR adds the ability to prompt the user for the client secret and password. The `gopass` library is used to securely prompt the user with asterisks, making it more secure than storing secrets in plaintext within the profile.